### PR TITLE
fix error-summary border not appearing & remove form-block class of intro

### DIFF
--- a/views/partials/form.html
+++ b/views/partials/form.html
@@ -1,0 +1,9 @@
+<form action="" method="POST" {{$encoding}}{{/encoding}} autocomplete="off" novalidate="true" spellcheck="false">
+  {{$intro}}
+    {{#intro}}<p>{{intro}}</p>{{/intro}}
+  {{/intro}}
+  {{$form}}{{/form}}
+  {{#csrf-token}}
+    <input type="hidden" name="x-csrf-token" value="{{csrf-token}}" />
+  {{/csrf-token}}
+</form>

--- a/views/partials/validation-summary.html
+++ b/views/partials/validation-summary.html
@@ -1,0 +1,24 @@
+{{#errorlist.length}}
+<div class="validation-summary error-summary" tabindex="-1">
+    {{$errorlist-title}}
+
+      {{#errorLength.single}}
+        <h2>{{#t}}errorlist.title.single{{/t}}</h2>
+      {{/errorLength.single}}
+      {{#errorLength.multiple}}
+        <h2>{{#t}}errorlist.title.multiple{{/t}}</h2>
+      {{/errorLength.multiple}}
+
+    {{/errorlist-title}}
+
+    {{<partials-validation-list}}
+        {{$validation-list}}
+            {{#errorlist}}
+                {{#message}}
+                  <li><a href="#{{key}}-group">{{ message }}</a></li>
+                {{/message}}
+            {{/errorlist}}
+        {{/validation-list}}
+    {{/partials-validation-list}}
+</div>
+{{/errorlist.length}}


### PR DESCRIPTION
Override the validation-summary template that adds the class for the redborder

Override the form template that has the 
form-block class was interfering with the error-summary validation class where it caused the text to move to the left
form-block class adds a float left and clear left but that doesn't really seem necessary 

I have also checked and the class validation-summary is still required so I have not removed it

**before change with the intro text**
<img width="653" alt="screen shot 2017-07-25 at 17 16 42" src="https://user-images.githubusercontent.com/12494656/28678412-3aa1f53a-72e8-11e7-84be-8e29076e8e4b.png">

**after change with intro text**

![screen shot 2017-07-27 at 16 20 05](https://user-images.githubusercontent.com/12494656/28678424-4748586a-72e8-11e7-97b5-74ff45e5fde0.png)
