### PR TITLE
Add a default images path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # hof-theme-govuk
+
+## Usage
+
+If you are using `hof-build` to build assets then you can add the following to your applications sass file.
+
+```
+@import "$$theme";
+```
+
+Otherwise add:
+
+```
+@import "hof-theme-govuk/styles/govuk";
+```
+
+(Note: is using npm-sass then the file path can be omitted, and only `@import: "hof-theme-govuk";` is required)
+
+## Configuration
+
+By default the compiled sass will attempt to load referenced images from `/public/images`. To override this, add the following to the top of your sass file (noting trailing slash):
+
+```
+$path: "/path/to/your/images/";
+```

--- a/styles/govuk.scss
+++ b/styles/govuk.scss
@@ -1,5 +1,8 @@
 // App styles
 
+// set the default image directory
+$path: "/public/images/" !default;
+
 // GOV.UK front end toolkit
 // Sass variables, mixins and functions
 // https://github.com/alphagov/govuk_frontend_toolkit/tree/master/stylesheets


### PR DESCRIPTION
This allows the `file-url` mixin included in govuk-frontend-toolkit to correctly resolve image paths according to a default hof implementation.