### PR TITLE
Remove additional margins on `#content`

### DIFF
--- a/styles/_layout.scss
+++ b/styles/_layout.scss
@@ -5,6 +5,10 @@
     }
 }
 
+#content {
+    margin: 0;
+}
+
 .main {
     @extend %site-width-container;
     padding-bottom: $gutter;
@@ -16,6 +20,9 @@
 .grid-row {
     @extend %grid-row;
     position: relative;
+    &#content {
+        @extend %grid-row;
+    }
 }
 
 .column-full {


### PR DESCRIPTION
This is a workaround for the issues in govuk elements (https://github.com/alphagov/govuk_elements/issues/585) and govuk template (https://github.com/alphagov/govuk_template/issues/271) which add additional margins to the `#content` element which is used for the "skip to content" link in the govuk template.

Because we add `#content` to a `.grid-row` element by default in hof, we need to ensure that when this is the case that the margins are inherited from the grid behaviour, and not set to zero.