### PR TITLE
update hof-template-partials to 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-theme-govuk",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "",
   "main": "index.js",
   "browser": "./client-js/index.js",
@@ -22,6 +22,6 @@
     "govuk-elements-sass": "^3.0.3",
     "hof-frontend-toolkit": "^2.1.0",
     "hof-govuk-template": "^2.0.1",
-    "hof-template-partials": "^4.0.0"
+    "hof-template-partials": "^4.2.0"
   }
 }


### PR DESCRIPTION
This is to include the changes as per GDS guidelines:
* move error summary to the top
* add an error prefix to the title