### PR TITLE
Fix hints to options for radio and checkbox groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-theme-govuk",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-theme-govuk",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "",
   "main": "index.js",
   "browser": "./client-js/index.js",

--- a/views/partials/forms/option-group.html
+++ b/views/partials/forms/option-group.html
@@ -15,12 +15,12 @@
                 required="true"
                 {{#toggle}} data-toggle="{{toggle}}"{{/toggle}}
                 {{#selected}} checked="checked"{{/selected}}
-                {{^error}}{{#hint}} aria-describedby="{{key}}-{{value}}-hint"{{/hint}}{{/error}}
+                {{^error}}{{#optionHint}} aria-describedby="{{key}}-{{value}}-hint"{{/optionHint}}{{^optionHint}}{{#hint}} aria-describedby="{{key}}-hint"{{/hint}}{{/optionHint}}{{/error}}
                 {{#error}} aria-describedby="{{key}}-error" aria-invalid="true"{{/error}}
             >
             <label class="block-label" for="{{key}}-{{value}}">
                 {{{label}}}
-                {{#hint}}<span id="{{key}}-{{value}}-hint" class="form-hint">{{hint}}</span>{{/hint}}
+                {{#optionHint}}<span id="{{key}}-{{value}}-hint" class="form-hint">{{optionHint}}</span>{{/optionHint}}
             </label>
         </div>
         {{#renderChild}}{{/renderChild}}


### PR DESCRIPTION
reference `optionHint` field to avoid conflicts with parent `hint` field 

aria-describedBy is the option hint if one is present, falling back to the hint of the parent field otherwise.

![Screenshot 2020-04-20 at 13 44 36](https://user-images.githubusercontent.com/45763982/79870429-e2d5e800-83da-11ea-881d-cd7d7fed0fca.png)