### PR TITLE
SD-744 non essential cookies opted out by default

### DIFF
--- a/client-js/cookieSettings.js
+++ b/client-js/cookieSettings.js
@@ -100,7 +100,7 @@ function initialiseFormControls() {
   if (preferences !== null && preferences.usage !== undefined && typeof preferences.usage === "boolean") {
     usage = preferences.usage;
   } else {
-    usage = true;
+    usage = false;
   }
 
   document.getElementById('radio-1').checked = usage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-theme-govuk",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2195,9 +2195,9 @@
       }
     },
     "hof-template-partials": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/hof-template-partials/-/hof-template-partials-5.2.1.tgz",
-      "integrity": "sha512-fm82KGUYOcpNCYQq3bxMmYSPIkbhLMAO43iHcvkX+EbQwgdYuShRBEE7ZFMQpzcaXuVfHH/zBLhIXJi6tlHVdQ==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/hof-template-partials/-/hof-template-partials-5.3.5.tgz",
+      "integrity": "sha512-YJp/1S7KkiA/8NylGCjj2VOC/rB03z2m+KP95sGVhHrPsjOLh7VfplGCzCxShnywtMQXTvIpcALEG75UoNedvQ==",
       "requires": {
         "lodash": "^4.17.4"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-theme-govuk",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "",
   "main": "index.js",
   "browser": "./client-js/index.js",
@@ -22,7 +22,7 @@
     "govuk-elements-sass": "^3.0.3",
     "hof-frontend-toolkit": "^2.1.0",
     "hof-govuk-template": "^2.0.1",
-    "hof-template-partials": "^5.1.1"
+    "hof-template-partials": "^5.3.5"
   },
   "devDependencies": {
     "@types/jest": "^26.0.14",

--- a/test/cookieBanner.test.js
+++ b/test/cookieBanner.test.js
@@ -165,18 +165,18 @@ describe('ga-tag', () => {
         expect(document.getElementById('radio-2').checked).toEqual(false);
       });
 
-      test('it should set first radio button checked if usage is not defined', () => {
+      test('it should set second radio button checked if usage is not defined', () => {
         GOVUK.cookie.mockReturnValueOnce('{}');
         cookieSettings.initialiseCookiePage();
-        expect(document.getElementById('radio-1').checked).toEqual(true);
-        expect(document.getElementById('radio-2').checked).toEqual(false);
+        expect(document.getElementById('radio-1').checked).toEqual(false);
+        expect(document.getElementById('radio-2').checked).toEqual(true);
       });
 
-      test('it should set first radio button checked if preferences is unset', () => {
+      test('it should set second radio button checked if preferences is unset', () => {
         GOVUK.cookie.mockReturnValueOnce(null);
         cookieSettings.initialiseCookiePage();
-        expect(document.getElementById('radio-1').checked).toEqual(true);
-        expect(document.getElementById('radio-2').checked).toEqual(false);
+        expect(document.getElementById('radio-1').checked).toEqual(false);
+        expect(document.getElementById('radio-2').checked).toEqual(true);
       });
 
       test('it should set second radio button checked if usage is false', () => {


### PR DESCRIPTION
# What
update cookieSettings.js so that non essential cookies radio button is set to opted out by default

# Why
GDPR compliance states cookie should be opt in

# How 
modified function initialiseFormControls to set 'radio-2' to checked if preferences are not set yet

# Test
updated two unit tests to reflect this and tested locally